### PR TITLE
[Bugfix]: fix the bug by bumping illuminate/contracts to version 10 and above

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^2.0",
-        "illuminate/contracts": "^9.0",
+        "illuminate/contracts": "^10.0",
         "spatie/laravel-package-tools": "^1.13.0"
     },
     "require-dev": {


### PR DESCRIPTION
A bug fix for this [https://github.com/discoverlance-com/filament-page-hints/issues/18](issue). The solution only bumps the version of illuminate/contracts to version 10 and above.

I am unsure if it will support version 9, so optionally there could be version 2. x which will support laravel 10 and above.